### PR TITLE
Nil Layout

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,4 +1,7 @@
 class SitemapsController < ApplicationController
+  
+  layout nil
+  
   def sitemap
     new_page!
     instance_eval &Sitemap::Map.draw_block


### PR DESCRIPTION
Hi,

When I installed your plugin, it gave me an XML parsing error because the sitemaps controller was using my application layout. I added a nil layout declaration to the controller in the plugin, and now it works right out of the box. Thanks for writing this plugin. It's quite handy!

-Aubrey
