### PR TITLE
undefined method `underscore' for ActiveModel

### DIFF
--- a/lib/dynamic_sitemaps/generator.rb
+++ b/lib/dynamic_sitemaps/generator.rb
@@ -58,7 +58,7 @@ module DynamicSitemaps
     def sitemap_for(collection, options = {}, &block)
       raise ArgumentError, "The collection given to `sitemap_for` must respond to #find_each. This is for performance. Use `Model.scoped` to get an ActiveRecord relation that responds to #find_each." unless collection.respond_to?(:find_each)
 
-      name = options.delete(:name) || collection.model_name.underscore.pluralize.to_sym
+      name = options.delete(:name) || collection.model_name.to_s.underscore.pluralize.to_sym
       options[:collection] = collection
 
       sitemap(name, options, &block)


### PR DESCRIPTION
Since the ActiveModel::Name in Rails 4 is not a String anymore before to get the model name to generate the sitemap, it should be changed to string

``` ruby
name = options.delete(:name) || collection.model_name.underscore.pluralize.to_sym
```

because in Rails 4 it throw the next exception:

```
Generating sitemap...
I, [2013-07-31T17:43:59.899011 #6631]  INFO -- : Generating sitemap...
rake aborted!
undefined method `underscore' for #<ActiveModel::Name:0x007f95cc8e7290>
/Users/joselo/.rvm/gems/ruby-2.0.0-p195@bolido/gems/dynamic_sitemaps-2.0.0.beta2/lib/dynamic_sitemaps/generator.rb:61:in `sitemap_for'
```
