### PR TITLE
Changed "scoped" to "where(nil)" for Rails 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ end
 # Automatically link to all pages using the routes specified
 # using "resources :pages" in config/routes.rb. This will also
 # automatically set <lastmod> to the date and time in page.updated_at.
-sitemap_for Page.scoped
+sitemap_for Page.where(nil)
 
 # For products with special sitemap name and priority, and link to comments
 sitemap_for Product.published, name: :published_products do |product|
@@ -111,7 +111,7 @@ This generates the sitemap files `site.xml`, `pages.xml`, and `published_product
 
 The argument passed to `sitemap_for` needs to respond to [`#find_each`](http://api.rubyonrails.org/classes/ActiveRecord/Batches.html#method-i-find_each), like an ActiveRecord [Relation](http://api.rubyonrails.org/classes/ActiveRecord/Relation.html).
 This is to ensure that the records from the database are lazy loaded 1,000 at a time, so that it doesn't accidentally load millions of records in one call when the configuration file is read.
-Therefore we use `Page.scoped` instead of the normal `Page.all`.
+Therefore we use `Page.where(nil)` instead of the normal `Page.all`.
 
 ## Custom configuration
 
@@ -187,7 +187,7 @@ Site.all.each do |site|
 
   sitemap_for site.pages.where("slug != 'home'")
   sitemap_for site.blog_posts.published
-  sitemap_for site.tags.scoped
+  sitemap_for site.tags.where(nil)
 
   sitemap_for site.products.where("type_id != ?", ProductType.find_by_key("unknown").id) do |product|
     url product, last_mod: product.updated_at, priority: (product.featured? ? 1.0 : 0.7)

--- a/lib/dynamic_sitemaps/generator.rb
+++ b/lib/dynamic_sitemaps/generator.rb
@@ -59,7 +59,7 @@ module DynamicSitemaps
     end
 
     def sitemap_for(collection, options = {}, &block)
-      raise ArgumentError, "The collection given to `sitemap_for` must respond to #find_each. This is for performance. Use `Model.scoped` to get an ActiveRecord relation that responds to #find_each." unless collection.respond_to?(:find_each)
+      raise ArgumentError, "The collection given to `sitemap_for` must respond to #find_each. This is for performance. Use `Model.where(nil)` to get an ActiveRecord relation that responds to #find_each." unless collection.respond_to?(:find_each)
 
       name = options.delete(:name) || collection.model_name.to_s.underscore.pluralize.to_sym
       options[:collection] = collection

--- a/lib/generators/dynamic_sitemaps/templates/config.rb
+++ b/lib/generators/dynamic_sitemaps/templates/config.rb
@@ -13,7 +13,7 @@ end
 # using "resources :pages" in config/routes.rb. This will also
 # automatically set <lastmod> to the date and time in page.updated_at:
 #
-#   sitemap_for Page.scoped
+#   sitemap_for Page.where(nil)
 
 # For products with special sitemap name and priority, and link to comments:
 #
@@ -33,7 +33,7 @@ end
 #       url root_url
 #     end
 # 
-#     sitemap_for site.products.scoped
+#     sitemap_for site.products.where(nil)
 #   end
 
 # Ping search engines after sitemap generation:

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -66,7 +66,7 @@ class GeneratorTest < ActiveSupport::TestCase
         url root_url
       end
 
-      sitemap_for Product.scoped do |product|
+      sitemap_for Product.where(nil) do |product|
         url product
         url product_comments_url(product)
       end
@@ -117,7 +117,7 @@ class GeneratorTest < ActiveSupport::TestCase
         end
       end
 
-      sitemap_for Product.scoped do |product|
+      sitemap_for Product.where(nil) do |product|
         url product
         url product_comments_url(product)
       end
@@ -206,7 +206,7 @@ class GeneratorTest < ActiveSupport::TestCase
     assert_raises ArgumentError do
       DynamicSitemaps.generate_sitemap do
         host "www.example.com"
-        sitemap_for Product.scoped
+        sitemap_for Product.where(nil)
         sitemap_for Product.where(id: 1)
       end
     end
@@ -218,10 +218,10 @@ class GeneratorTest < ActiveSupport::TestCase
         host "www.example.com"
 
         folder "sitemaps/one"
-        sitemap_for Product.scoped
+        sitemap_for Product.where(nil)
 
         folder "sitemaps/two"
-        sitemap_for Product.scoped
+        sitemap_for Product.where(nil)
       end
     end
   end
@@ -272,7 +272,7 @@ class GeneratorTest < ActiveSupport::TestCase
 
     DynamicSitemaps.generate_sitemap do
       host "www.mytest.com"
-      sitemap_for Product.scoped
+      sitemap_for Product.where(nil)
     end
 
     doc = open_sitemap
@@ -300,7 +300,7 @@ class GeneratorTest < ActiveSupport::TestCase
 
     DynamicSitemaps.generate_sitemap do
       host "www.mytest.com"
-      sitemap_for Product.scoped do |product|
+      sitemap_for Product.where(nil) do |product|
         url product, last_mod: 1234.seconds.ago, priority: (product.featured? ? 1.0 : nil), change_freq: "weekly"
         url product_comments_url(product)
       end


### PR DESCRIPTION
The "Model.scoped" function is deprecated for Rails 4. The identical way to achieve a "scoped" call in Rails 4 is a "where(nil)" call. I replaced all "scoped" calls throughout with "where(nil)". Tested the gem locally and everything still works perfectly.
