### PR TITLE
Change /robots.txt routes to avoid template missing error

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ In `config/routes.rb`:
 
 ```ruby
 get "sitemap.xml" => "home#sitemap", format: :xml, as: :sitemap
-get "robots.txt" => "home#robots", format: :text, as: :robots
+get "robots.:format" => "home#robots", format: :text, as: :robots
 ```
 
 #### Controller


### PR DESCRIPTION
Template missing error has occurred in [routing-the-default-sitemap](https://github.com/lassebunk/dynamic_sitemaps#routing-the-default-sitemap) part (Rails 4.2.3)

Changed README.md file to prevent it.
