### PR TITLE
dont remove base dir every time

### DIFF
--- a/lib/dynamic_sitemaps/generator.rb
+++ b/lib/dynamic_sitemaps/generator.rb
@@ -29,10 +29,17 @@ module DynamicSitemaps
       FileUtils.rm_rf DynamicSitemaps.temp_path
     end
 
+    def create_base_dir(folder)
+      destination = File.join(DynamicSitemaps.path, folder)
+      FileUtils.mkdir_p destination
+      destination
+    end
+
     def move_to_destination
-      sitemaps.map(&:folder).uniq.each do |folder|
-        destination = File.join(DynamicSitemaps.path, folder)
-        FileUtils.mkdir_p destination
+      sitemaps_folder = sitemaps.map(&:folder).uniq - [DynamicSitemaps.folder]
+      create_base_dir(DynamicSitemaps.folder)
+      sitemaps_folder.each do |folder|
+        destination = create_base_dir(folder)
         FileUtils.rm_rf Dir.glob(File.join(destination, "*"))
 
         temp_files = File.join(DynamicSitemaps.temp_path, folder, "*.xml")

--- a/lib/dynamic_sitemaps/generator.rb
+++ b/lib/dynamic_sitemaps/generator.rb
@@ -29,18 +29,11 @@ module DynamicSitemaps
       FileUtils.rm_rf DynamicSitemaps.temp_path
     end
 
-    def create_base_dir(folder)
-      destination = File.join(DynamicSitemaps.path, folder)
-      FileUtils.mkdir_p destination
-      destination
-    end
-
     def move_to_destination
-      sitemaps_folder = sitemaps.map(&:folder).uniq - [DynamicSitemaps.folder]
-      create_base_dir(DynamicSitemaps.folder)
-      sitemaps_folder.each do |folder|
-        destination = create_base_dir(folder)
-        FileUtils.rm_rf Dir.glob(File.join(destination, "*"))
+      sitemaps.map(&:folder).uniq.each do |folder|
+        destination = File.join(DynamicSitemaps.path, folder)
+        FileUtils.mkdir_p destination
+        FileUtils.rm_rf(Dir.glob(File.join(destination, "*"))) unless folder == DynamicSitemaps.folder
 
         temp_files = File.join(DynamicSitemaps.temp_path, folder, "*.xml")
         FileUtils.mv Dir.glob(temp_files), destination


### PR DESCRIPTION
The problem:
I have many subdomain and many of them haven't got any page modifications(CRUD). So in sitemap.rb i made this:

```
unless File.exist?([Rails.root.to_s, "public/sitemaps/#{item.slug}/sitemap.xml"].join("/"))
....
end
```

And when i run task 'sitemap:generate' i have the problem: all old sitemaps was deleted.
This issue happened because base sitemaps directory deleted every time, when script start to moving files. Sitemap array has DynamicSitemaps.path at first position.
I create base directory and don't remove all files from them.
