### PR TITLE
Fix #43: protocol can be now set in configure block

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ In an initializer, e.g. `config/initializers/dynamic_sitemaps.rb`:
 # These are the built-in defaults, so you don't need to specify them.
 DynamicSitemaps.configure do |config|
   config.path = Rails.root.join("public")
+  config.protocol = "https"
   config.folder = "sitemaps" # This folder is emptied on each sitemap generation
   config.index_file_name = "sitemap.xml"
   config.always_generate_index = false # Makes sitemap.xml contain the sitemap

--- a/lib/dynamic_sitemaps.rb
+++ b/lib/dynamic_sitemaps.rb
@@ -34,6 +34,7 @@ module DynamicSitemaps
     #   DynamicSitemaps.configure do |config|
     #     config.path = Rails.root.join("public")
     #     config.folder = "sitemaps"
+    #     config.protocol = "https"
     #     config.index_file_name = "sitemap.xml"
     #     config.always_generate_index = false
     #     config.config_path = Rails.root.join("config", "sitemap.rb")
@@ -109,6 +110,12 @@ module DynamicSitemaps
 
     def protocol
       @protocol ||= DEFAULT_PROTOCOL
+    end
+
+    def protocol=(new_protocol)
+      raise ArgumentError, "DynamicSitemaps.protocol can't be blank." if new_protocol.blank?
+      Rails.application.routes.default_url_options[:protocol] = new_protocol.to_s
+      @protocol = new_protocol.to_s
     end
 
     # Resets all instance variables. Used for testing.


### PR DESCRIPTION
Configure like so:
```
DynamicSitemaps.configure do |config|
  config.protocol = 'https'
end
```
DynamicSitemaps#protocol also accepts symbol, `config.protocol = :https` will be valid as well.